### PR TITLE
Fix rolling build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
   micro_ros_azure_app:
     runs-on: ubuntu-latest
-    container: ubuntu:20.04
+    container: ubuntu:24.04
     strategy:
       matrix:
         azure_rtos_version: [v6.1.7_rel]
@@ -27,7 +27,7 @@ jobs:
           apt update
           export DEBIAN_FRONTEND=noninteractive
           apt install -y --no-install-recommends git build-essential gcc-arm-none-eabi python3-pip cmake ninja-build libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib g++-multilib gcc-multilib binutils-arm-none-eabi
-          pip3 install catkin_pkg lark-parser colcon-common-extensions
+          pip3 install catkin_pkg lark-parser colcon-common-extensions --break-system-packages
       - uses: actions/checkout@v2
         with:
           path: repo

--- a/lib/netx_driver/inventek/wifi.c
+++ b/lib/netx_driver/inventek/wifi.c
@@ -572,7 +572,7 @@ WIFI_Status_t WIFI_GetModuleFwRevision(char *rev)
 {
   WIFI_Status_t ret = WIFI_STATUS_ERROR;
   
-  if(EsWifiObj.FW_Rev != NULL)
+  if(EsWifiObj.FW_Rev[0] != '\0')
   {
     strncpy(rev, (char *)EsWifiObj.FW_Rev, ES_WIFI_FW_REV_SIZE);
     ret = WIFI_STATUS_OK;
@@ -589,7 +589,7 @@ WIFI_Status_t WIFI_GetModuleID(char *Id)
 {
   WIFI_Status_t ret = WIFI_STATUS_ERROR;
   
-  if(EsWifiObj.Product_ID != NULL)
+  if(EsWifiObj.Product_ID[0] != '\0')
   {
     strncpy(Id, (char *)EsWifiObj.Product_ID, ES_WIFI_PRODUCT_ID_SIZE);
     ret = WIFI_STATUS_OK;
@@ -606,7 +606,7 @@ WIFI_Status_t WIFI_GetModuleName(char *ModuleName)
 {
   WIFI_Status_t ret = WIFI_STATUS_ERROR;
   
-  if(EsWifiObj.Product_Name != NULL)
+  if(EsWifiObj.Product_Name[0] != '\0')
   {
     strncpy(ModuleName, (char *)EsWifiObj.Product_Name, ES_WIFI_PRODUCT_NAME_SIZE);
     ret = WIFI_STATUS_OK;

--- a/microros/libmicroros.mk
+++ b/microros/libmicroros.mk
@@ -43,6 +43,7 @@ $(EXTENSIONS_DIR)/micro_ros_dev/install:
 	git clone -b rolling https://github.com/ament/googletest src/googletest; \
 	git clone -b rolling https://github.com/ros2/ament_cmake_ros src/ament_cmake_ros; \
 	git clone -b rolling https://github.com/ament/ament_index src/ament_index; \
+	touch src/ament_cmake_ros/rmw_test_fixture_implementation/COLCON_IGNORE; \
 	colcon build --cmake-args -DBUILD_TESTING=OFF -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=gcc;
 
 $(EXTENSIONS_DIR)/micro_ros_src/src:


### PR DESCRIPTION
This PR fixes rolling build, that was broken due to new module added to ament_cmake_ros (see https://github.com/ros2/ament_cmake_ros/pull/21).

 - Fix by adding a COLCON_IGNORE to this module.
 - Also fix a warning that was breaking build.
 - Bump Ubuntu to 24.04 in rolling CI.